### PR TITLE
Fix log messages and cache of jaas configuration file

### DIFF
--- a/docker/data.txt
+++ b/docker/data.txt
@@ -1,0 +1,10 @@
+{
+  "value_schema_id": 1,"records": [ {
+       "value": {
+         "name":"REST API Test 2 Standalone",
+         "dept":101,
+         "salary":10010.0
+       }
+     }
+   ]
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,13 +45,13 @@ services:
       #KAFKA INTERBROKER SECURITY
       KAFKA_SECURITY_INTER_BROKER_PROTOCOL: PLAINTEXT
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=DEBUG,org.apache.kafka=DEBUG"
-      KAFKA_LOG4J_ROOT_LOGLEVEL: DEBUG
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,org.apache.kafka=INFO"
+      KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
       ############## Authorizer ######################
       KAFKA_AUTHORIZER_CLASS_NAME: "kafka.security.auth.SimpleAclAuthorizer"
       KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
       # Access denials are logged at INFO level, change to DEBUG to also log allowed accesses
-      KAFKA_LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER: "DEBUG, authorizerAppender"
+      KAFKA_LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER: "INFO, authorizerAppender"
       KAFKA_LOG4J_ADDITIVITY_KAFKA_AUTHORIZER_LOGGER: "false"
 
   schema-registry:
@@ -98,8 +98,8 @@ services:
       #Only need for confluentinc/kafka-rest container
       CUB_CLASSPATH: "/etc/confluent/docker/docker-utils.jar:/usr/share/java/kafka-rest/kafka-ims-rest-1.0-SNAPSHOT-jar-with-dependencies.jar -Djava.security.auth.login.config=/etc/kafka-rest/kafka_rest_proxy_jaas.conf"
       ################# log4j ########################
-      KAFKA_REST_LOG4J_LOGGERS: "kafka.controller=INFO,org.apache.kafka=INFO"
-      KAFKA_REST_LOG4J_ROOT_LOGLEVEL: INFO
+      KAFKA_REST_LOG4J_LOGGERS: "kafka.controller=DEBUG,org.apache.kafka=DEBUG"
+      KAFKA_REST_LOG4J_ROOT_LOGLEVEL: DEBUG
 
   hawtio-jmx:
     image: upala-corporation/hawtio-jmx

--- a/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/cache/CachePrincipal.java
+++ b/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/cache/CachePrincipal.java
@@ -1,0 +1,73 @@
+package com.adobe.ids.dim.security.rest.cache;
+
+import avro.shaded.com.google.common.cache.CacheBuilder;
+import avro.shaded.com.google.common.cache.CacheLoader;
+import avro.shaded.com.google.common.cache.LoadingCache;
+import com.adobe.ids.dim.security.rest.config.KafkaOAuthSecurityRestConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class CachePrincipal {
+
+    private static final Logger log = LoggerFactory.getLogger(CachePrincipal.class);
+    private LoadingCache<String, KafkaOAuthSecurityRestConfig> mapConfiguration;
+    private static CachePrincipal principal;
+
+    public static CachePrincipal getInstance(){
+        if(principal == null){
+            principal = new CachePrincipal(5, TimeUnit.MINUTES);
+        }
+        return principal;
+    }
+
+    public CachePrincipal(long duration, TimeUnit timeUnit){
+        this.mapConfiguration = CacheBuilder.newBuilder()
+                .expireAfterWrite(duration, timeUnit)
+                .concurrencyLevel(10)
+                .build(new CacheLoader<String, KafkaOAuthSecurityRestConfig>() {
+                    @Override
+                    public KafkaOAuthSecurityRestConfig load(String s) {
+                        return null;
+                    }
+                });
+    }
+
+    public KafkaOAuthSecurityRestConfig get(String s) {
+        KafkaOAuthSecurityRestConfig result = null;
+        try {
+            String hashKey = UUID.nameUUIDFromBytes(s.getBytes()).toString();
+            result = this.mapConfiguration.get(hashKey);
+            log.debug("Get configuration from cache map");
+            log.debug("Key: " + s);
+            log.debug("HashKey: " + hashKey);
+            log.debug("Map: " + result.toString());
+        } catch (ExecutionException e) {
+            log.debug("Concurrent access to cache configuration of dinamically jaas file. Creating a new one.");
+        } catch (CacheLoader.InvalidCacheLoadException e) {
+            log.trace("Principal not found on cache. Return null to creating a new one");
+        }
+        return result;
+    }
+
+    public void put(String s, KafkaOAuthSecurityRestConfig item){
+        String hashKey = UUID.nameUUIDFromBytes(s.getBytes()).toString();
+        log.debug("Put configuration on cache map");
+        log.debug("Key: " + s);
+        log.debug("HashKey: " + hashKey);
+        log.debug("Map: " + item.toString());
+        this.mapConfiguration.put(hashKey, item);
+    }
+
+    public void remove(String s){
+        String hashKey = UUID.nameUUIDFromBytes(s.getBytes()).toString();
+        log.debug("Remove configuration from cache map");
+        log.debug("Key: " + s);
+        log.debug("HashKey: " + hashKey);
+        this.mapConfiguration.invalidate(hashKey);
+    }
+
+}

--- a/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/config/KafkaOAuthSecurityRestConfig.java
+++ b/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/config/KafkaOAuthSecurityRestConfig.java
@@ -17,9 +17,10 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.Properties;
 
-public final class KafkaOAuthSecurityRestConfig extends KafkaRestConfig {
+public final class KafkaOAuthSecurityRestConfig extends KafkaRestConfig implements Serializable {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaOAuthSecurityRestConfig.class);
     private static final ConfigDef configDef = createBaseConfigDef();

--- a/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/filter/OAuthCleanerFilter.java
+++ b/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/filter/OAuthCleanerFilter.java
@@ -15,7 +15,7 @@ public class OAuthCleanerFilter implements ContainerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(OAuthCleanerFilter.class);
 
     public void filter(final ContainerRequestContext requestContext) {
-        OAuthCleanerFilter.log.debug("Cleaning up thread " + Thread.currentThread().getName());
+        log.debug("Cleaning up thread " + Thread.currentThread().getName());
         KafkaRestContextProvider.clearCurrentContext();
     }
 }

--- a/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/filter/OAuthFilter.java
+++ b/kafka-ims-rest/src/main/java/com/adobe/ids/dim/security/rest/filter/OAuthFilter.java
@@ -8,9 +8,7 @@ import com.adobe.ids.dim.security.rest.config.KafkaOAuthSecurityRestConfig;
 import com.adobe.ids.dim.security.rest.context.KafkaOAuthRestContextFactory;
 import io.confluent.kafkarest.KafkaRestContext;
 import io.confluent.kafkarest.extension.KafkaRestContextProvider;
-import io.confluent.kafkarest.resources.v2.ConsumersResource;
 import io.confluent.rest.RestConfigException;
-import io.confluent.rest.exceptions.RestNotAuthorizedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kafka-ims-rest/src/test/java/com/adobe/ids/dim/security/rest/IMSCacheTest.java
+++ b/kafka-ims-rest/src/test/java/com/adobe/ids/dim/security/rest/IMSCacheTest.java
@@ -1,0 +1,64 @@
+package com.adobe.ids.dim.security.rest;
+
+import com.adobe.ids.dim.security.common.IMSBearerTokenJwt;
+import com.adobe.ids.dim.security.rest.cache.CachePrincipal;
+import com.adobe.ids.dim.security.rest.config.KafkaOAuthSecurityRestConfig;
+import io.confluent.rest.RestConfigException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class IMSCacheTest {
+
+    CachePrincipal principal;
+    KafkaOAuthSecurityRestConfig item;
+    IMSBearerTokenJwt imsBearerTokenJwt;
+
+    @Before
+    public void setUp() throws RestConfigException {
+        principal = new CachePrincipal(5, TimeUnit.SECONDS);
+
+        Properties prop = new Properties();
+        prop.put("test", "test.value");
+
+        Map<String, Object> jwtToken = new HashMap<String, Object>();
+        jwtToken.put("client_id", "DIM_SERVICE_ACCOUNT");
+        jwtToken.put("scope", "dim.core.services");
+        jwtToken.put("expires_in", "600");
+        jwtToken.put("created_at", "0");
+        String randomAccessToken = "asdjfklsdfoeuirrnmncxoiuereklr";
+
+        imsBearerTokenJwt = new IMSBearerTokenJwt(jwtToken, randomAccessToken);
+        item = new KafkaOAuthSecurityRestConfig(prop, imsBearerTokenJwt);
+    }
+
+    @Test
+    public void TestCacheInsert(){
+        principal.put("test.principal", item);
+        assertEquals(item, principal.get("test.principal"));
+    }
+
+    @Test
+    public void TestCacheInvalidate(){
+        principal.put("test.principal", item);
+        assertEquals(item, principal.get("test.principal"));
+        principal.remove("test.principal");
+        assertNull(principal.get("test.principal"));
+    }
+
+    @Test
+    public void TestCacheInvalidateByTime() throws InterruptedException {
+        principal.put("test.principal", item);
+        assertEquals(item, principal.get("test.principal"));
+        Thread.sleep(6000);
+        assertNull(principal.get("test.principal"));
+    }
+
+}


### PR DESCRIPTION
- Fix log message output on OAuthResponseFilter class
- Fix cache of jaas configuration file on OAuthRequestFilter class
- Create of class CachePrincipal that handles the cache of jaas configuration files with TTL (5 minutes)
- Invalidate cache of that principal when some error occurs on OAuthResponseFilter